### PR TITLE
Use a static require context

### DIFF
--- a/src/template-entry-import-require-context-static.js
+++ b/src/template-entry-import-require-context-static.js
@@ -1,0 +1,8 @@
+const requireContext = require.context(
+  "./template",
+  true,
+  /.*\.stories\.loader\.jsx$/
+);
+
+export const importFn = (name) =>
+  requireContext(name.replace(".stories.", ".stories.loader.")).importFn();

--- a/src/template/Button.stories.loader.jsx
+++ b/src/template/Button.stories.loader.jsx
@@ -1,0 +1,1 @@
+export const importFn = async () => import('./Button.stories')

--- a/src/template/Header.stories.loader.jsx
+++ b/src/template/Header.stories.loader.jsx
@@ -1,0 +1,1 @@
+export const importFn = async () => import('./Header.stories')

--- a/src/template/Page.stories.loader.jsx
+++ b/src/template/Page.stories.loader.jsx
@@ -1,0 +1,1 @@
+export const importFn = async () => import('./Page.stories')


### PR DESCRIPTION
Based on https://github.com/tmeasday/storybook-skeleton/pull/12

The idea here is to work around the (apparent) lack of support for lazy require contexts with lazy compilation.

So instead:

- In the entry point, we create a *normal* (non-lazy) require context.
- The require context points at special "async import" modules that themselves simply import (but async) the thing we really wanted to import in the original require context.

So in a sense we are implementing our own lazy require context via a non-lazy require context and a bunch of lazy "proxy" imports.

I am guessing there is some way to achieve this without manually creating the `.stories.import.jsx` files, but instead getting webpack to do it via some special loader? I was thinking something like

1. Transform any file `.stories.jsx` to a simple import proxy (i.e. like what we have in `Pages.stories.import.jsx`).
2. That file imports the *same file* (is that allowed?) but via a different loader (`import('./Pages.stories.jsx!no-proxy-loader')`)
3. That different "loader" just doesn't do step 1 (so emits the file as normal).

I got this idea from browsing through NextJS's source to see how they do the equivalent thing. I don't pretend to understand the nuance but I did see this: 

https://github.com/vercel/next.js/blob/0af3b526408bae26d6b3f8cab75c4229998bf7cb/packages/next/build/webpack/loaders/next-client-pages-loader.ts#L24-L30
