### PR TITLE
Use Chrome 90 as a compilation target

### DIFF
--- a/webpack.parts.js
+++ b/webpack.parts.js
@@ -8,7 +8,7 @@ const builderAlternatives = {
     exclude: /node_modules/,
     options: {
       loader: "tsx",
-      target: "es2015",
+      target: "chrome90",
     },
   },
   swc: {
@@ -16,6 +16,9 @@ const builderAlternatives = {
     loader: "swc-loader",
     exclude: /node_modules/,
     options: {
+      env: {
+        target: { chrome: "90" },
+      },
       jsc: {
         parser: {
           syntax: "typescript",


### PR DESCRIPTION
We needed this for babel, as otherwise we need to add `babel-runtime` as an entry point, which is possible but sort of a pain. I figure let's just target Chrome in our experiments for now.

WDYT @bebraw?