### PR TITLE
feat: Load lodash and React from a CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The following additional parameters are supported:
 - `PROFILE_CPU=1` - Enables [the CPU profiler](https://github.com/jantimon/cpuprofile-webpack-plugin) and emits a flamegraph that can be examined using Chrome Inspector.
 - `ENABLE_SOURCE_MAPS=1` - Enables generation of source maps
 - `ENABLE_FS_CACHE=1` - Enabled webpack's file system level cache
+- `ENABLE_CDN=1` - Load Lodash and React from a CDN
 
 2. Run the prebuild manager:
 

--- a/compose-configuration.js
+++ b/compose-configuration.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
+const WebpackCdnPlugin = require("webpack-cdn-plugin");
 const { merge } = require("webpack-merge");
 const parts = require("./webpack.parts");
 
@@ -44,6 +45,7 @@ function composeConfiguration({
   enableSourceMaps,
   enableFsCache,
   devServer,
+  enableCdn,
 }) {
   let targetConfiguration;
 
@@ -81,7 +83,38 @@ function composeConfiguration({
     enableFsCache ? { cache: { type: "filesystem" } } : {},
     parts[devServer]({ project }),
     aliases({ project, importStyle }),
-    vertical ? parts.splitVertically : {}
+    vertical ? parts.splitVertically : {},
+    enableCdn
+      ? {
+          externals: {
+            lodash: "lodash",
+            react: "React",
+            "react-dom": "ReactDOM",
+          },
+          plugins: [
+            new WebpackCdnPlugin({
+              modules: [
+                {
+                  name: "lodash",
+                  var: "_",
+                  path: "lodash.min.js",
+                },
+                {
+                  name: "react",
+                  var: "React",
+                  path: "umd/react.development.js",
+                },
+                {
+                  name: "react-dom",
+                  var: "ReactDOM",
+                  path: "umd/react-dom.development.js",
+                },
+              ],
+              publicPath: "/node_modules",
+            }),
+          ],
+        }
+      : {}
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "style-loader": "^2.0.0",
     "swc-loader": "^0.1.14",
     "webpack": "^5.36.2",
+    "webpack-cdn-plugin": "^3.3.1",
     "webpack-cli": "^4.7.0",
     "webpack-dev-server": "^3.11.2",
     "webpack-merge": "^5.7.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -12,4 +12,5 @@ module.exports = composeConfiguration({
   enableSourceMaps: process.env.ENABLE_SOURCE_MAPS === "1",
   enableFsCache: process.env.ENABLE_FS_CACHE === "1",
   devServer: process.env.DEV_SERVER || "wds",
+  enableCdn: process.env.ENABLE_CDN === "1",
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5619,7 +5619,7 @@ repeat-string@^1.6.1:
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request@^2.88.2:
+request@^2.85.0, request@^2.88.2:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -6146,6 +6146,19 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
+sri-create@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/sri-create/-/sri-create-0.0.3.tgz#35ba419e6d9381299615cd164c96d09b1e0e2128"
+  integrity sha512-4ZL3TLvPvu0y/3YpTkZdd441ykiRnrdWJuvus99WIT7NWTS2Dl/dFdZ7j0+zuL8cZPAKG2qGSdB+OLTBMRNuyQ==
+  dependencies:
+    request "^2.85.0"
+    sri "^1.1.0"
+
+sri@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/sri/-/sri-1.1.0.tgz#0b5cf64620e490b95fd805b0c710d7669c53cdfe"
+  integrity sha1-C1z2RiDkkLlf2AWwxxDXZpxTzf4=
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -6712,6 +6725,13 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
+
+webpack-cdn-plugin@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/webpack-cdn-plugin/-/webpack-cdn-plugin-3.3.1.tgz#7e08855ab3fc0af6859f0b49620dc81f58914e23"
+  integrity sha512-xwhQ6xstFbPlgEkKNAOjXs/6YkPdzYeXl9na+CSBF7p1L88PZIGgL++vel4oiAnp+WTud7fhnSjlB79U6aN28w==
+  dependencies:
+    sri-create "^0.0.3"
 
 webpack-cli@^4.7.0:
   version "4.7.0"


### PR DESCRIPTION
To test: `PROJECT=design-system COMPILE_LAZILY=1 BUILDER=esbuild IMPORT=static ENABLE_CDN=1 yarn start-wds`.

**Before CDN**

<img width="666" alt="Screen Shot 2021-06-08 at 16 05 48" src="https://user-images.githubusercontent.com/166921/121190457-c2354f80-c873-11eb-9d99-843b874d3b24.png">

**After CDN**

<img width="664" alt="Screen Shot 2021-06-08 at 16 05 01" src="https://user-images.githubusercontent.com/166921/121190484-c82b3080-c873-11eb-8eda-dae2a784cc8f.png">

If I'm interpreting correctly, that's cutting about half of the time.

Related to #18.