### PR TITLE
feat: Add plugin/loader profiler

### DIFF
--- a/compose-configuration.js
+++ b/compose-configuration.js
@@ -60,7 +60,7 @@ function composeConfiguration({
       throw new Error(`Unknown target: ${target}`);
   }
 
-  return merge(
+  const config = merge(
     commonConfig,
     {
       module: {
@@ -83,6 +83,18 @@ function composeConfiguration({
     aliases({ project, importStyle }),
     vertical ? parts.splitVertically : {}
   );
+
+  if (profileCpu) {
+    const SpeedMeasurePlugin = require("speed-measure-webpack-plugin");
+    const smp = new SpeedMeasurePlugin({
+      // Experimental and not totally accurate
+      granularLoaderData: true,
+    });
+
+    return smp.wrap(config);
+  }
+
+  return config;
 }
 
 module.exports = composeConfiguration;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-svg-loader": "^3.0.3",
     "rimraf": "^3.0.2",
     "snowpack": "^3.4.0",
+    "speed-measure-webpack-plugin": "^1.5.0",
     "style-loader": "^2.0.0",
     "swc-loader": "^0.1.14",
     "webpack": "^5.36.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6135,6 +6135,13 @@ spdy@^4.0.2:
     select-hose "^2.0.0"
     spdy-transport "^3.0.0"
 
+speed-measure-webpack-plugin@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/speed-measure-webpack-plugin/-/speed-measure-webpack-plugin-1.5.0.tgz#caf2c5bee24ab66c1c7c30e8daa7910497f7681a"
+  integrity sha512-Re0wX5CtM6gW7bZA64ONOfEPEhwbiSF/vz6e2GvadjuaPrQcHTQdRGsD8+BE7iUOysXH8tIenkPCQBEcspXsNg==
+  dependencies:
+    chalk "^4.1.0"
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"


### PR DESCRIPTION
I added the profiler behind `PROFILE_CPU=1` as it felt related.

Screenshot:

<img width="805" alt="Screen Shot 2021-06-08 at 16 44 44" src="https://user-images.githubusercontent.com/166921/121196254-ffe8a700-c878-11eb-9943-f39ce2c32f12.png">

It's useful but not probably as useful as we expected. Thanks to composition, it was easy to plug in.

Related to #21.