### PR TITLE
feat: Add a minimal API for loading stories in the background

### DIFF
--- a/src/storybook/index.js
+++ b/src/storybook/index.js
@@ -20,6 +20,12 @@ export async function configure(importFn, storiesJson, globalConfig = {}) {
   const params = new URLSearchParams(document.location.search);
   const storyId = params.get("id");
 
+  window.sb = {
+    listStories: () => console.log(Object.keys(storiesJson.stories)),
+    importStory: (storyId) =>
+      importFn(storiesJson.stories[storyId].parameters.fileName),
+  };
+
   send({
     type: "setStories",
     args: [


### PR DESCRIPTION
I added two new methods to `http://localhost:5000/iframe.html`: `window.sb.listStories()` and `window.sb.importStory(name)`.

I believe this feature will allow us to prefetch the stories we want.

The problem with regular `fetch` is that I don't know which resource it should fetch exactly. To work around this, I went through `importFn` in the code as that's doing the right thing underneath. That's not to say this cannot be changed to `fetch` later if we figure that out but this gives the basic capability we need for optimistic loading.

To test, run using `PROJECT=design-system COMPILE_LAZILY=1 BUILDER=esbuild IMPORT=require-context ENABLE_CDN=1 yarn start-wds` (likely other options work too).

I expect you know how to call the iframe bit from manager to trigger compilation. I think there's some kind of channel in place and I think you have access to iframe globals as well so triggering the methods there could be an option.

Here's a screenshot of the solution in action:

<img width="808" alt="Screen Shot 2021-06-10 at 15 22 57" src="https://user-images.githubusercontent.com/166921/121524677-36046300-ca00-11eb-923c-0418769ed92e.png">

Related to #17.